### PR TITLE
Add activity filters to frontend

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Activity Filters Feature
+
+## Description
+This pull request adds activity filters to the frontend, allowing users to filter activities by name and schedule. The new controls are located above the activities list.
+
+## Changes
+- Added search box and schedule dropdown to `index.html`
+- Updated `app.js` to filter activities in real time
+- No backend changes required
+
+## How to test
+1. Switch to the `feature/activity-filters` branch.
+2. Open the web app and use the filter controls above the activities list.
+3. Verify that activities are filtered as expected.
+
+## Related Issue
+Resolves: Add filters for activities
+
+---
+Please review and merge if everything looks good.

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,63 +3,76 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const filterName = document.getElementById("filter-name");
+  const filterSchedule = document.getElementById("filter-schedule");
+  let allActivities = {};
 
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
       const response = await fetch("/activities");
-      const activities = await response.json();
+      allActivities = await response.json();
+      renderActivities();
+      // Render activities based on filters
+      function renderActivities() {
+        // Clear loading message
+        activitiesList.innerHTML = "";
+        activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
-      // Clear loading message
-      activitiesList.innerHTML = "";
+        // Get filter values
+        const nameFilter = filterName.value.toLowerCase();
+        const scheduleFilter = filterSchedule.value;
 
-      // Populate activities list
-      Object.entries(activities).forEach(([name, details]) => {
-        const activityCard = document.createElement("div");
-        activityCard.className = "activity-card";
+        Object.entries(allActivities).forEach(([name, details]) => {
+          // Filter by name
+          if (nameFilter && !name.toLowerCase().includes(nameFilter)) return;
+          // Filter by schedule
+          if (scheduleFilter && !details.schedule.includes(scheduleFilter)) return;
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+          const activityCard = document.createElement("div");
+          activityCard.className = "activity-card";
 
-        // Create participants HTML with delete icons instead of bullet points
-        const participantsHTML =
-          details.participants.length > 0
-            ? `<div class="participants-section">
-              <h5>Participants:</h5>
-              <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
-              </ul>
-            </div>`
-            : `<p><em>No participants yet</em></p>`;
+          const spotsLeft = details.max_participants - details.participants.length;
 
-        activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-          <div class="participants-container">
-            ${participantsHTML}
-          </div>
-        `;
+          const participantsHTML =
+            details.participants.length > 0
+              ? `<div class="participants-section">
+                  <h5>Participants:</h5>
+                  <ul class="participants-list">
+                    ${details.participants
+                      .map(
+                        (email) =>
+                          `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      )
+                      .join("")}
+                  </ul>
+                </div>`
+              : `<p><em>No participants yet</em></p>`;
 
-        activitiesList.appendChild(activityCard);
+          activityCard.innerHTML = `
+            <h4>${name}</h4>
+            <p>${details.description}</p>
+            <p><strong>Schedule:</strong> ${details.schedule}</p>
+            <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+            <div class="participants-container">
+              ${participantsHTML}
+            </div>
+          `;
 
-        // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        activitySelect.appendChild(option);
-      });
+          activitiesList.appendChild(activityCard);
 
-      // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+          // Add option to select dropdown
+          const option = document.createElement("option");
+          option.value = name;
+          option.textContent = name;
+          activitySelect.appendChild(option);
+        });
+
+        // Add event listeners to delete buttons
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -154,6 +167,10 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error signing up:", error);
     }
   });
+
+  // Filter event listeners
+  filterName.addEventListener("input", renderActivities);
+  filterSchedule.addEventListener("change", renderActivities);
 
   // Initialize app
   fetchActivities();

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -14,7 +14,18 @@
 
     <main>
       <section id="activities-container">
-        <h3>Available Activities</h3>
+          <h3>Available Activities</h3>
+          <div id="activity-filters" style="margin-bottom: 16px;">
+            <input type="text" id="filter-name" placeholder="Search by name..." style="padding: 8px; width: 180px; margin-right: 10px;" />
+            <select id="filter-schedule" style="padding: 8px;">
+              <option value="">All Schedules</option>
+              <option value="Fridays">Fridays</option>
+              <option value="Tuesdays">Tuesdays</option>
+              <option value="Thursdays">Thursdays</option>
+              <option value="Mondays">Mondays</option>
+              <option value="Wednesdays">Wednesdays</option>
+            </select>
+          </div>
         <div id="activities-list">
           <!-- Activities will be loaded here -->
           <p>Loading activities...</p>


### PR DESCRIPTION
This pull request adds activity filters to the frontend, allowing users to filter activities by name and schedule. The new controls are located above the activities list.

**Changes:**
- Added search box and schedule dropdown to `index.html`
- Updated `app.js` to filter activities in real time
- No backend changes required

**How to test:**
1. Switch to the `feature/activity-filters` branch.
2. Open the web app and use the filter controls above the activities list.
3. Verify that activities are filtered as expected.

Resolves: Add filters for activities